### PR TITLE
update error handling

### DIFF
--- a/src/app/_api/fetchDoc.ts
+++ b/src/app/_api/fetchDoc.ts
@@ -37,12 +37,12 @@ const queryMap = {
   },
 }
 
-export const fetchDoc = async <T>(args: {
-  collection: keyof Config['collections']
+export const fetchDoc = async <T extends keyof Config['collections']>(args: {
+  collection: T
   slug?: string
   id?: string
   draft?: boolean
-}): Promise<T> => {
+}): Promise<Config['collections'][T]> => {
   const { collection, slug, draft } = args || {}
 
   if (!queryMap[collection]) throw new Error(`Collection ${collection} not found`)

--- a/src/app/_api/fetchDoc.ts
+++ b/src/app/_api/fetchDoc.ts
@@ -35,46 +35,6 @@ const queryMap = {
     query: TALK,
     key: 'TalksAndRoundtables',
   },
-  'podcast-episodes': {
-    query: PODCAST_EPISODE,
-    key: 'PodcastEpisodes',
-  },
-  authors: {
-    query: AUTHOR,
-    key: 'Authors',
-  },
-  blogposts: {
-    query: BLOGPOST,
-    key: 'Blogposts',
-  },
-  'case-studies': {
-    query: CASE_STUDY,
-    key: 'CaseStudies',
-  },
-  'talks-and-roundtables': {
-    query: TALK,
-    key: 'TalksAndRoundtables',
-  },
-  'podcast-episodes': {
-    query: PODCAST_EPISODE,
-    key: 'PodcastEpisodes',
-  },
-  authors: {
-    query: AUTHOR,
-    key: 'Authors',
-  },
-  blogposts: {
-    query: BLOGPOST,
-    key: 'Blogposts',
-  },
-  'case-studies': {
-    query: CASE_STUDY,
-    key: 'CaseStudies',
-  },
-  'talks-and-roundtables': {
-    query: TALK,
-    key: 'TalksAndRoundtables',
-  },
 }
 
 export const fetchDoc = async <T>(args: {
@@ -94,27 +54,31 @@ export const fetchDoc = async <T>(args: {
     token = cookies().get(payloadToken)
   }
 
-  const doc: T = await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token?.value && draft ? { Authorization: `JWT ${token.value}` } : {}),
-    },
-    cache: 'no-store',
-    next: { tags: [`${collection}_${slug}`] },
-    body: JSON.stringify({
-      query: queryMap[collection].query,
-      variables: {
-        slug,
-        draft,
+  try {
+    const doc: T = await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token?.value && draft ? { Authorization: `JWT ${token.value}` } : {}),
       },
-    }),
-  })
-    ?.then(res => res.json())
-    ?.then(res => {
-      if (res.errors) throw new Error(res?.errors?.[0]?.message ?? 'Error fetching doc')
-      return res?.data?.[queryMap[collection].key]?.docs?.[0]
+      cache: 'no-store',
+      next: { tags: [`${collection}_${slug}`] },
+      body: JSON.stringify({
+        query: queryMap[collection].query,
+        variables: {
+          slug,
+          draft,
+        },
+      }),
     })
+      ?.then(res => res.json())
+      ?.then(res => {
+        if (res.errors) throw new Error(res?.errors?.[0]?.message ?? 'Error fetching doc')
+        return res?.data?.[queryMap[collection].key]?.docs?.[0]
+      })
 
-  return doc
+    return doc
+  } catch (err: unknown) {
+    throw new Error('Error fetching doc:', err)
+  }
 }


### PR DESCRIPTION
Adresses Issue #19 

Why: 
- `fetchDoc` had poor error handling, which was being performed when the function was call on the different content pages;
How:
- added a try/catch block to `fetchDoc` to ensure error handling inside the function;