### PR TITLE
create socials collection

### DIFF
--- a/src/app/_api/fetchGlobals.ts
+++ b/src/app/_api/fetchGlobals.ts
@@ -1,11 +1,11 @@
-import type { Footer, Header, Settings } from '../../payload/payload-types'
-import { FOOTER_QUERY, HEADER_QUERY, SETTINGS_QUERY } from '../_graphql/globals'
+import type { Footer, Header, Settings, Social } from '../../payload/payload-types'
+import { FOOTER_QUERY, HEADER_QUERY, SETTINGS_QUERY, SOCIALS_QUERY } from '../_graphql/globals'
 import { GRAPHQL_API_URL } from './shared'
 
 export async function fetchSettings(): Promise<Settings> {
   if (!GRAPHQL_API_URL) throw new Error('NEXT_PUBLIC_SERVER_URL not found')
 
-  const settings = await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+  return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -23,14 +23,12 @@ export async function fetchSettings(): Promise<Settings> {
       if (res?.errors) throw new Error(res?.errors[0]?.message || 'Error fetching settings')
       return res.data?.Settings
     })
-
-  return settings
 }
 
 export async function fetchHeader(): Promise<Header> {
   if (!GRAPHQL_API_URL) throw new Error('NEXT_PUBLIC_SERVER_URL not found')
 
-  const header = await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+  return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -48,14 +46,12 @@ export async function fetchHeader(): Promise<Header> {
       if (res?.errors) throw new Error(res?.errors[0]?.message || 'Error fetching header')
       return res.data?.Header
     })
-
-  return header
 }
 
 export async function fetchFooter(): Promise<Footer> {
   if (!GRAPHQL_API_URL) throw new Error('NEXT_PUBLIC_SERVER_URL not found')
 
-  const footer = await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+  return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -72,14 +68,33 @@ export async function fetchFooter(): Promise<Footer> {
       if (res?.errors) throw new Error(res?.errors[0]?.message || 'Error fetching footer')
       return res.data?.Footer
     })
+}
 
-  return footer
+export async function fetchSocials(): Promise<Social> {
+  if (!GRAPHQL_API_URL) throw new Error('NEXT_PUBLIC_SERVER_URL not found')
+
+  return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    cache: 'no-store',
+    body: JSON.stringify({
+      query: SOCIALS_QUERY,
+    }),
+  })
+    ?.then(res => res.json())
+    ?.then(res => {
+      if (res?.errors) throw new Error(res?.errors[0]?.message || 'Error fetching socials')
+      return res.data?.Social
+    })
 }
 
 export const fetchGlobals = async (): Promise<{
   settings: Settings
   header: Header
   footer: Footer
+  socials: Social
 }> => {
   // initiate requests in parallel, then wait for them to resolve
   // this will eagerly start to the fetch requests at the same time
@@ -87,16 +102,16 @@ export const fetchGlobals = async (): Promise<{
   const settingsData = fetchSettings()
   const headerData = fetchHeader()
   const footerData = fetchFooter()
+  const socialsData = fetchSocials()
 
-  const [settings, header, footer]: [Settings, Header, Footer] = await Promise.all([
-    await settingsData,
-    await headerData,
-    await footerData,
-  ])
+  const [settings, header, footer, socials]: [Settings, Header, Footer, Social] = await Promise.all(
+    [await settingsData, await headerData, await footerData, await socialsData],
+  )
 
   return {
     settings,
     header,
     footer,
+    socials,
   }
 }

--- a/src/app/_api/fetchGlobals.ts
+++ b/src/app/_api/fetchGlobals.ts
@@ -1,93 +1,109 @@
-import type { Footer, Header, Settings, Social } from '../../payload/payload-types'
-import { FOOTER_QUERY, HEADER_QUERY, SETTINGS_QUERY, SOCIALS_QUERY } from '../_graphql/globals'
-import { GRAPHQL_API_URL } from './shared'
+import type { Footer, Header, Settings, Social } from "../../payload/payload-types";
+import { FOOTER_QUERY, HEADER_QUERY, SETTINGS_QUERY, SOCIALS_QUERY } from "../_graphql/globals";
+import { GRAPHQL_API_URL } from "./shared";
 
 export async function fetchSettings(): Promise<Settings> {
-  if (!GRAPHQL_API_URL) throw new Error('NEXT_PUBLIC_SERVER_URL not found')
+  if (!GRAPHQL_API_URL) throw new Error("NEXT_PUBLIC_SERVER_URL not found");
 
-  return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-store',
-    body: JSON.stringify({
-      query: SETTINGS_QUERY,
-    }),
-  })
-    ?.then(res => {
-      if (!res.ok) throw new Error('Error fetching doc')
-      return res.json()
+  try {
+    return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      cache: "no-store",
+      body: JSON.stringify({
+        query: SETTINGS_QUERY,
+      }),
     })
-    ?.then(res => {
-      if (res?.errors) throw new Error(res?.errors[0]?.message || 'Error fetching settings')
-      return res.data?.Settings
-    })
+      ?.then(res => {
+        if (!res.ok) throw new Error("Error fetching doc");
+        return res.json();
+      })
+      ?.then(res => {
+        if (res?.errors) throw new Error(res?.errors[0]?.message || "Error fetching settings");
+        return res.data?.Settings;
+      });
+  } catch (err: unknown) {
+    throw new Error("Error fetching settings")
+  }
 }
 
 export async function fetchHeader(): Promise<Header> {
-  if (!GRAPHQL_API_URL) throw new Error('NEXT_PUBLIC_SERVER_URL not found')
+  if (!GRAPHQL_API_URL) throw new Error("NEXT_PUBLIC_SERVER_URL not found");
 
-  return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-store',
-    body: JSON.stringify({
-      query: HEADER_QUERY,
-    }),
-  })
-    ?.then(res => {
-      if (!res.ok) throw new Error('Error fetching doc')
-      return res.json()
+  try {
+    return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      cache: "no-store",
+      body: JSON.stringify({
+        query: HEADER_QUERY,
+      }),
     })
-    ?.then(res => {
-      if (res?.errors) throw new Error(res?.errors[0]?.message || 'Error fetching header')
-      return res.data?.Header
-    })
+      ?.then(res => {
+        if (!res.ok) throw new Error("Error fetching doc");
+        return res.json();
+      })
+      ?.then(res => {
+        if (res?.errors) throw new Error(res?.errors[0]?.message || "Error fetching header");
+        return res.data?.Header;
+      });
+  } catch (err: unknown) {
+    throw new Error("Error fetching header");
+  }
 }
 
 export async function fetchFooter(): Promise<Footer> {
-  if (!GRAPHQL_API_URL) throw new Error('NEXT_PUBLIC_SERVER_URL not found')
+  if (!GRAPHQL_API_URL) throw new Error("NEXT_PUBLIC_SERVER_URL not found");
 
-  return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      query: FOOTER_QUERY,
-    }),
-  })
-    .then(res => {
-      if (!res.ok) throw new Error('Error fetching doc')
-      return res.json()
+  try {
+    return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: FOOTER_QUERY,
+      }),
     })
-    ?.then(res => {
-      if (res?.errors) throw new Error(res?.errors[0]?.message || 'Error fetching footer')
-      return res.data?.Footer
-    })
+      .then(res => {
+        if (!res.ok) throw new Error("Error fetching doc");
+        return res.json();
+      })
+      ?.then(res => {
+        if (res?.errors) throw new Error(res?.errors[0]?.message || "Error fetching footer");
+        return res.data?.Footer;
+      });
+  } catch (err: unknown) {
+    throw new Error("Error fetching footer");
+  }
 }
 
 export async function fetchSocials(): Promise<Social> {
-  if (!GRAPHQL_API_URL) throw new Error('NEXT_PUBLIC_SERVER_URL not found')
+  if (!GRAPHQL_API_URL) throw new Error("NEXT_PUBLIC_SERVER_URL not found");
 
-  return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-store',
-    body: JSON.stringify({
-      query: SOCIALS_QUERY,
-    }),
-  })
-    ?.then(res => res.json())
-    ?.then(res => {
-      if (res?.errors) throw new Error(res?.errors[0]?.message || 'Error fetching socials')
-      return res.data?.Social
+  try {
+    return await fetch(`${GRAPHQL_API_URL}/api/graphql`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      cache: "no-store",
+      body: JSON.stringify({
+        query: SOCIALS_QUERY,
+      }),
     })
+      ?.then(res => res.json())
+      ?.then(res => {
+        if (res?.errors) throw new Error(res?.errors[0]?.message || "Error fetching socials");
+        return res.data?.Social;
+      });
+  } catch (err: unknown) {
+    throw new Error("Error fetching socials");
+  }
 }
 
 export const fetchGlobals = async (): Promise<{
@@ -99,19 +115,19 @@ export const fetchGlobals = async (): Promise<{
   // initiate requests in parallel, then wait for them to resolve
   // this will eagerly start to the fetch requests at the same time
   // see https://nextjs.org/docs/app/building-your-application/data-fetching/fetching
-  const settingsData = fetchSettings()
-  const headerData = fetchHeader()
-  const footerData = fetchFooter()
-  const socialsData = fetchSocials()
+  const settingsData = fetchSettings();
+  const headerData = fetchHeader();
+  const footerData = fetchFooter();
+  const socialsData = fetchSocials();
 
   const [settings, header, footer, socials]: [Settings, Header, Footer, Social] = await Promise.all(
     [await settingsData, await headerData, await footerData, await socialsData],
-  )
+  );
 
   return {
     settings,
     header,
     footer,
     socials,
-  }
-}
+  };
+};

--- a/src/app/_graphql/globals.ts
+++ b/src/app/_graphql/globals.ts
@@ -44,3 +44,21 @@ query Settings {
   ${SETTINGS}
 }
 `
+
+export const SOCIALS = `
+  Socials {
+      name
+      link
+    }
+`
+
+export const SOCIALS_QUERY = `
+query Socials {
+  Social {
+    socials {
+      name
+      link
+    }
+  }
+}
+`

--- a/src/payload/generated-schema.graphql
+++ b/src/payload/generated-schema.graphql
@@ -59,6 +59,8 @@ type Query {
   docAccessHeader: headerDocAccess
   Footer(draft: Boolean): Footer
   docAccessFooter: footerDocAccess
+  Social(draft: Boolean): Social
+  docAccessSocial: socialsDocAccess
   Access: Access
 }
 
@@ -9709,6 +9711,185 @@ type FooterUpdateDocAccess {
   where: JSONObject
 }
 
+type Social {
+  socials: [Social_Socials!]
+  updatedAt: DateTime
+  createdAt: DateTime
+}
+
+type Social_Socials {
+  name: String
+  link: String
+  id: String
+}
+
+type socialsDocAccess {
+  fields: SocialsDocAccessFields
+  read: SocialsReadDocAccess
+  update: SocialsUpdateDocAccess
+}
+
+type SocialsDocAccessFields {
+  socials: SocialsDocAccessFields_socials
+  updatedAt: SocialsDocAccessFields_updatedAt
+  createdAt: SocialsDocAccessFields_createdAt
+}
+
+type SocialsDocAccessFields_socials {
+  create: SocialsDocAccessFields_socials_Create
+  read: SocialsDocAccessFields_socials_Read
+  update: SocialsDocAccessFields_socials_Update
+  delete: SocialsDocAccessFields_socials_Delete
+  fields: SocialsDocAccessFields_socials_Fields
+}
+
+type SocialsDocAccessFields_socials_Create {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_Read {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_Update {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_Delete {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_Fields {
+  name: SocialsDocAccessFields_socials_name
+  link: SocialsDocAccessFields_socials_link
+  id: SocialsDocAccessFields_socials_id
+}
+
+type SocialsDocAccessFields_socials_name {
+  create: SocialsDocAccessFields_socials_name_Create
+  read: SocialsDocAccessFields_socials_name_Read
+  update: SocialsDocAccessFields_socials_name_Update
+  delete: SocialsDocAccessFields_socials_name_Delete
+}
+
+type SocialsDocAccessFields_socials_name_Create {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_name_Read {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_name_Update {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_name_Delete {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_link {
+  create: SocialsDocAccessFields_socials_link_Create
+  read: SocialsDocAccessFields_socials_link_Read
+  update: SocialsDocAccessFields_socials_link_Update
+  delete: SocialsDocAccessFields_socials_link_Delete
+}
+
+type SocialsDocAccessFields_socials_link_Create {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_link_Read {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_link_Update {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_link_Delete {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_id {
+  create: SocialsDocAccessFields_socials_id_Create
+  read: SocialsDocAccessFields_socials_id_Read
+  update: SocialsDocAccessFields_socials_id_Update
+  delete: SocialsDocAccessFields_socials_id_Delete
+}
+
+type SocialsDocAccessFields_socials_id_Create {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_id_Read {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_id_Update {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_socials_id_Delete {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_updatedAt {
+  create: SocialsDocAccessFields_updatedAt_Create
+  read: SocialsDocAccessFields_updatedAt_Read
+  update: SocialsDocAccessFields_updatedAt_Update
+  delete: SocialsDocAccessFields_updatedAt_Delete
+}
+
+type SocialsDocAccessFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_createdAt {
+  create: SocialsDocAccessFields_createdAt_Create
+  read: SocialsDocAccessFields_createdAt_Read
+  update: SocialsDocAccessFields_createdAt_Update
+  delete: SocialsDocAccessFields_createdAt_Delete
+}
+
+type SocialsDocAccessFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type SocialsDocAccessFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type SocialsReadDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type SocialsUpdateDocAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type Access {
   canAccessAdmin: Boolean!
   pages: pagesAccess
@@ -9724,6 +9905,7 @@ type Access {
   settings: settingsAccess
   header: headerAccess
   footer: footerAccess
+  socials: socialsAccess
 }
 
 type pagesAccess {
@@ -13283,6 +13465,173 @@ type FooterUpdateAccess {
   where: JSONObject
 }
 
+type socialsAccess {
+  fields: SocialsFields
+  read: SocialsReadAccess
+  update: SocialsUpdateAccess
+}
+
+type SocialsFields {
+  socials: SocialsFields_socials
+  updatedAt: SocialsFields_updatedAt
+  createdAt: SocialsFields_createdAt
+}
+
+type SocialsFields_socials {
+  create: SocialsFields_socials_Create
+  read: SocialsFields_socials_Read
+  update: SocialsFields_socials_Update
+  delete: SocialsFields_socials_Delete
+  fields: SocialsFields_socials_Fields
+}
+
+type SocialsFields_socials_Create {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_Read {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_Update {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_Delete {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_Fields {
+  name: SocialsFields_socials_name
+  link: SocialsFields_socials_link
+  id: SocialsFields_socials_id
+}
+
+type SocialsFields_socials_name {
+  create: SocialsFields_socials_name_Create
+  read: SocialsFields_socials_name_Read
+  update: SocialsFields_socials_name_Update
+  delete: SocialsFields_socials_name_Delete
+}
+
+type SocialsFields_socials_name_Create {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_name_Read {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_name_Update {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_name_Delete {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_link {
+  create: SocialsFields_socials_link_Create
+  read: SocialsFields_socials_link_Read
+  update: SocialsFields_socials_link_Update
+  delete: SocialsFields_socials_link_Delete
+}
+
+type SocialsFields_socials_link_Create {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_link_Read {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_link_Update {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_link_Delete {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_id {
+  create: SocialsFields_socials_id_Create
+  read: SocialsFields_socials_id_Read
+  update: SocialsFields_socials_id_Update
+  delete: SocialsFields_socials_id_Delete
+}
+
+type SocialsFields_socials_id_Create {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_id_Read {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_id_Update {
+  permission: Boolean!
+}
+
+type SocialsFields_socials_id_Delete {
+  permission: Boolean!
+}
+
+type SocialsFields_updatedAt {
+  create: SocialsFields_updatedAt_Create
+  read: SocialsFields_updatedAt_Read
+  update: SocialsFields_updatedAt_Update
+  delete: SocialsFields_updatedAt_Delete
+}
+
+type SocialsFields_updatedAt_Create {
+  permission: Boolean!
+}
+
+type SocialsFields_updatedAt_Read {
+  permission: Boolean!
+}
+
+type SocialsFields_updatedAt_Update {
+  permission: Boolean!
+}
+
+type SocialsFields_updatedAt_Delete {
+  permission: Boolean!
+}
+
+type SocialsFields_createdAt {
+  create: SocialsFields_createdAt_Create
+  read: SocialsFields_createdAt_Read
+  update: SocialsFields_createdAt_Update
+  delete: SocialsFields_createdAt_Delete
+}
+
+type SocialsFields_createdAt_Create {
+  permission: Boolean!
+}
+
+type SocialsFields_createdAt_Read {
+  permission: Boolean!
+}
+
+type SocialsFields_createdAt_Update {
+  permission: Boolean!
+}
+
+type SocialsFields_createdAt_Delete {
+  permission: Boolean!
+}
+
+type SocialsReadAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
+type SocialsUpdateAccess {
+  permission: Boolean!
+  where: JSONObject
+}
+
 type Mutation {
   createPage(data: mutationPageInput!, draft: Boolean): Page
   updatePage(id: String!, autosave: Boolean, data: mutationPageUpdateInput!, draft: Boolean): Page
@@ -13330,6 +13679,7 @@ type Mutation {
   updateSettings(data: mutationSettingsInput!, draft: Boolean): Settings
   updateHeader(data: mutationHeaderInput!, draft: Boolean): Header
   updateFooter(data: mutationFooterInput!, draft: Boolean): Footer
+  updateSocial(data: mutationSocialInput!, draft: Boolean): Social
 }
 
 input mutationPageInput {
@@ -13861,4 +14211,16 @@ input Footer_NavItems_Link_ReferenceRelationshipInput {
 
 enum Footer_NavItems_Link_ReferenceRelationshipInputRelationTo {
   pages
+}
+
+input mutationSocialInput {
+  socials: [mutationSocial_SocialsInput]
+  updatedAt: String
+  createdAt: String
+}
+
+input mutationSocial_SocialsInput {
+  name: String!
+  link: String!
+  id: String
 }

--- a/src/payload/globals/Socials.ts
+++ b/src/payload/globals/Socials.ts
@@ -1,0 +1,29 @@
+import type { GlobalConfig } from "payload/types";
+
+import link from "../fields/link";
+
+export const Socials: GlobalConfig = {
+  slug: "socials",
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      name: "socials",
+      type: "array",
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'link',
+          type: 'text',
+          required: true,
+        },
+      ],
+    },
+  ],
+
+};

--- a/src/payload/payload-types.ts
+++ b/src/payload/payload-types.ts
@@ -24,6 +24,7 @@ export interface Config {
     settings: Settings;
     header: Header;
     footer: Footer;
+    socials: Social;
   };
 }
 /**
@@ -372,6 +373,22 @@ export interface Footer {
           url?: string | null;
           label: string;
         };
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "socials".
+ */
+export interface Social {
+  id: string;
+  socials?:
+    | {
+        name: string;
+        link: string;
         id?: string | null;
       }[]
     | null;

--- a/src/payload/payload.config.ts
+++ b/src/payload/payload.config.ts
@@ -21,6 +21,7 @@ import BeforeLogin from './components/BeforeLogin'
 import { Footer } from './globals/Footer'
 import { Header } from './globals/Header'
 import { Settings } from './globals/Settings'
+import { Socials } from './globals/Socials'
 
 dotenv.config({
   path: path.resolve(__dirname, '../../.env'),
@@ -71,7 +72,7 @@ export default buildConfig({
     TalksAndRoundtables,
     CaseStudies,
   ],
-  globals: [Settings, Header, Footer],
+  globals: [Settings, Header, Footer, Socials],
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts'),
   },


### PR DESCRIPTION
Why:
- Adding a collection dedicated to social media links is a flexible and useful way to populate fields such as the footer and social sharing blocks.
How:
- Created a `Socials` collection and updated `payload-config.ts`, `payload-types`, graphQL schema, graphQL queries and fetchers accordingly.