### PR TITLE
disable data caching for hub homepage

### DIFF
--- a/src/app/(pages)/[slug]/page.tsx
+++ b/src/app/(pages)/[slug]/page.tsx
@@ -3,6 +3,8 @@ import HubContentGrid from "@/app/_blocks/HubContentGrid";
 import HubHead from "@/app/_blocks/HubHead";
 import SearchBar from "@/app/_components/SearchBar";
 
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 export default async function Page() {
 
   const content = {

--- a/src/app/(pages)/page.tsx
+++ b/src/app/(pages)/page.tsx
@@ -1,5 +1,7 @@
 import PageTemplate from './[slug]/page'
 
+export const dynamic = 'auto'
+export const revalidate = 10
 
 export default PageTemplate
 

--- a/src/collections/Blogposts/Blogposts.ts
+++ b/src/collections/Blogposts/Blogposts.ts
@@ -4,12 +4,16 @@ import type { CollectionConfig } from 'payload'
 import { slugField } from '@/fields/slug'
 import { authenticated } from "@/access/authenticated";
 import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
+import { revalidatePost } from "@/collections/Blogposts/hooks";
 
 export const Blogposts: CollectionConfig = {
   slug: 'blogposts',
   admin: {
     useAsTitle: 'title',
     defaultColumns: ['title', 'slug', 'updatedAt'],
+  },
+  hooks: {
+    afterChange: [revalidatePost]
   },
   versions: { drafts: true },
   access: {

--- a/src/collections/Blogposts/hooks.ts
+++ b/src/collections/Blogposts/hooks.ts
@@ -1,0 +1,30 @@
+import type {CollectionAfterChangeHook} from "payload";
+
+import {revalidatePath} from "next/cache";
+
+import type {Blogpost} from "@/payload-types";
+
+export const revalidatePost: CollectionAfterChangeHook<Blogpost> = ({
+  doc,
+  previousDoc,
+  req: { payload },
+}) => {
+  if (doc._status === 'published') {
+    const path = `/blogposts/${doc.slug}`
+
+    payload.logger.info(`Revalidating blogpost at path: ${path}`)
+
+    revalidatePath(path)
+  }
+
+  if (previousDoc?._status === 'published' && doc._status !== 'published') {
+    const oldPath = `/posts/${previousDoc.slug}`
+
+    payload.logger.info(`Revalidating old blogpost at path: ${oldPath}`)
+
+    revalidatePath(oldPath)
+  }
+
+  return doc
+
+}

--- a/src/collections/Media/Media.ts
+++ b/src/collections/Media/Media.ts
@@ -1,0 +1,45 @@
+import type { CollectionConfig } from 'payload'
+
+import {
+  FixedToolbarFeature,
+  InlineToolbarFeature,
+  lexicalEditor,
+} from '@payloadcms/richtext-lexical'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { anyone } from '../../access/anyone'
+import { authenticated } from '../../access/authenticated'
+
+const filename = fileURLToPath(import.meta.url)
+const dirname = path.dirname(filename)
+
+export const Media: CollectionConfig = {
+  slug: 'media',
+  access: {
+    create: authenticated,
+    delete: authenticated,
+    read: anyone,
+    update: authenticated,
+  },
+  fields: [
+    {
+      name: 'alt',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'caption',
+      type: 'richText',
+      editor: lexicalEditor({
+        features: ({ rootFeatures }) => {
+          return [...rootFeatures, FixedToolbarFeature(), InlineToolbarFeature()]
+        },
+      }),
+    },
+  ],
+  upload: {
+    // Upload to the public/media directory in Next.js making them publicly accessible even outside of Payload
+    staticDir: path.resolve(dirname, '../../public/media'),
+  },
+}

--- a/src/collections/Podcasts/Podcasts.ts
+++ b/src/collections/Podcasts/Podcasts.ts
@@ -4,6 +4,7 @@ import { slugField } from '@/fields/slug'
 import { populatePublishedAt } from '@/hooks/populatePublishedAt'
 import { authenticatedOrPublished } from "@/access/authenticatedOrPublished";
 import { authenticated } from "@/access/authenticated";
+import { revalidatePodcast } from "@/collections/Podcasts/hooks";
 
 // TODO: Add preview;
 
@@ -15,6 +16,7 @@ export const Podcasts: CollectionConfig = {
   },
   hooks: {
     beforeChange: [populatePublishedAt],
+    afterChange: [revalidatePodcast],
   },
   versions: { drafts: true },
   access: {

--- a/src/collections/Podcasts/hooks.ts
+++ b/src/collections/Podcasts/hooks.ts
@@ -1,0 +1,30 @@
+import type {CollectionAfterChangeHook} from "payload";
+
+import {revalidatePath} from "next/cache";
+
+import type {Podcast} from "@/payload-types";
+
+export const revalidatePodcast: CollectionAfterChangeHook<Podcast> = ({
+  doc,
+  previousDoc,
+  req: { payload },
+}) => {
+  if (doc._status === 'published') {
+    const path = `/podcasts/${doc.slug}`
+
+    payload.logger.info(`Revalidating podcast at path: ${path}`)
+
+    revalidatePath(path)
+  }
+
+  if (previousDoc?._status === 'published' && doc._status !== 'published') {
+    const oldPath = `/podcasts/${previousDoc.slug}`
+
+    payload.logger.info(`Revalidating old podcast at path: ${oldPath}`)
+
+    revalidatePath(oldPath)
+  }
+
+  return doc
+
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -38,7 +38,7 @@ import { beforeSyncWithSearch } from '@/search/beforeSync'
 import { Blogposts } from "@/collections/Blogposts/Blogposts";
 import { Authors } from "@/collections/Authors";
 import { CaseStudies } from "@/collections/CaseStudies";
-import { Podcasts } from "@/collections/Podcasts";
+import { Podcasts } from "@/collections/Podcasts/Podcasts";
 import { TalksAndRoundtables } from "@/collections/TalksAndRoundtables";
 import { HomePageSettings } from "@/Globals/HubHighlights/config";
 

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -35,7 +35,7 @@ import { Page, Post } from 'src/payload-types'
 
 import { searchFields } from '@/search/fieldOverrides'
 import { beforeSyncWithSearch } from '@/search/beforeSync'
-import { Blogposts } from "@/collections/Blogposts";
+import { Blogposts } from "@/collections/Blogposts/Blogposts";
 import { Authors } from "@/collections/Authors";
 import { CaseStudies } from "@/collections/CaseStudies";
 import { Podcasts } from "@/collections/Podcasts";


### PR DESCRIPTION
Why:
- as mentioned on #55 , content was being cached and not fetching from the data based, which implied a redeployment in order to display fresh content. 
How:
 - setting `dynamic` to `force-dynamic` and `revalidate` to 0 disables caching and forces re-rendering/new data fetches on new requests as per [NextJS documentation](https://nextjs.org/docs/app/building-your-application/caching) 
 - collections were missing revalidation hooks that leverage NextJS [revalidatePath](https://nextjs.org/docs/app/api-reference/functions/revalidatePath) for incremental static regeneration;